### PR TITLE
added cargo project and db module draft

### DIFF
--- a/webserver/Cargo.toml
+++ b/webserver/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "theysaid"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = {version = "0.5", features = ["form"] }
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
+tower = "0.4"
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+rust-argon2 = "1.0"
+sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "mysql" ] }

--- a/webserver/src/db_wrapper/mod.rs
+++ b/webserver/src/db_wrapper/mod.rs
@@ -1,0 +1,17 @@
+use anyhow::*;
+use anyhow::Result;
+
+mod pool;
+pub use pool::MysqlDbWrapper;
+
+// todo - remove this, it's just an example
+pub async fn add_user_credentials(db: &MysqlDbWrapper, uname: &str, phc: &str, nick: &str) -> Result<()> {
+    sqlx::query("INSERT INTO AUTH (UNAME, PHC, NICK) VALUES (?, ?, ?)")
+    .bind(uname)
+    .bind(phc)
+    .bind(nick)
+    .execute(db.get_pool())
+    .await?; 
+  
+    Ok(())
+}

--- a/webserver/src/db_wrapper/pool.rs
+++ b/webserver/src/db_wrapper/pool.rs
@@ -1,0 +1,19 @@
+use anyhow::*;
+use sqlx::{mysql::*};
+use anyhow::Result;
+
+pub struct MysqlDbWrapper(MySqlPool);
+
+impl MysqlDbWrapper {
+    pub async fn new(url: &str) -> Result<Self> {
+        let pool = MySqlPoolOptions::new()
+            .max_connections(10)
+            .connect(url).await?;
+    
+        Ok(MysqlDbWrapper(pool))
+    }
+
+    pub (super) fn get_pool(&self) -> &MySqlPool {
+        &self.0
+    }
+}

--- a/webserver/src/main.rs
+++ b/webserver/src/main.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use anyhow::*;
+
+mod db_wrapper;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // DB url needs to be extracted from a config file, for now this is the spec
+    let db_url = "mysql://theysa_user:theysa_pass@localhost:3306/theysa_db";
+    let db = Arc::new(db_wrapper::MysqlDbWrapper::new(db_url).await?);
+
+    db_wrapper::add_user_credentials(&db, "test1", "1", "boh").await?;
+    db_wrapper::add_user_credentials(&db, "test2", "1", "boh").await?;
+    db_wrapper::add_user_credentials(&db, "test3", "1", "boh").await?;
+    db_wrapper::add_user_credentials(&db, "test4", "1", "boh").await?;
+    db_wrapper::add_user_credentials(&db, "test5", "1", "boh").await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Since this project is going to need a database, I've gone ahead and set up a little draft for it.

I suggest (and implemented) the use of the following libs:
- sqlx (for mysql)
- anyhow
- axum
- (and any dependency of the above)

I'd be happy to continue work on the db module, developing all the query handlers.

Right now the module exposes only:
```rust
pub struct MysqlDbWrapper(MySqlPool);
```
which is a wrapper to a connection pool to store in axum's global state.
I'd like for all of the query handlers to be pure functions, therefore this wrapper would have to be passed around quite a lot. I made it so that the underlying pool can be obtained only within the database module.

Hope this is satisfactory.